### PR TITLE
Local development build fails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 //
 
 plugins {
-    id 'org.asciidoctor.jvm.convert' version '3.3.0'
+    id 'org.asciidoctor.jvm.convert' version '4.0.4'
 }
 
 apply plugin: 'java'


### PR DESCRIPTION
Fixes #15

Updated the org.asciidoctor.jvm.convert gradle plugin to the latest stable release version